### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/content/changelog-howto.rst
+++ b/content/changelog-howto.rst
@@ -200,8 +200,8 @@ See you when I try it ;)
    http://tech.novapost.fr/git-history-matters-en.html#about-release-notes-changelog
 .. _`include CHANGELOG into Sphinx documentation`:
    https://github.com/diecutter/sphinx-quickstart/blob/master/template/docs/about/changelog.txt
-.. _`piecutter`: https://piecutter.readthedocs.org/
+.. _`piecutter`: https://piecutter.readthedocs.io/
 .. _`Sphinx`: http://sphinx-doc.org/
 .. _`git history matters`:
    http://tech.novapost.fr/git-history-matters-en.html
-.. _`zest.releaser`: http://zestreleaser.readthedocs.org/
+.. _`zest.releaser`: https://zestreleaser.readthedocs.io/

--- a/content/check_po.rst
+++ b/content/check_po.rst
@@ -125,4 +125,4 @@ garantir une bonne qualité de traduction à vos programmes, services et
 applications.
 
 .. _`une question sur serverfault`: http://superuser.com/questions/517276/after-a-gettext-update-be-able-to-check-if-a-translation-file-has-been-translate
-.. _polib: http://polib.readthedocs.org/en/latest/quickstart.html#more-examples
+.. _polib: https://polib.readthedocs.io/en/latest/quickstart.html#more-examples

--- a/content/diecutter-intro.rst
+++ b/content/diecutter-intro.rst
@@ -96,5 +96,5 @@ And here is a typical architecture we are thinking of:
   client.
 * you and your favorite client, i.e. web browser or shell.
 
-Then what about putting it together with `daybed <http://daybed.rtfd.org/>`_
+Then what about putting it together with `daybed <https://daybed.readthedocs.io/>`_
 for schema validation?

--- a/content/diecutter-release-0-5.rst
+++ b/content/diecutter-release-0-5.rst
@@ -9,7 +9,7 @@ diecutter.io reads templates on Github!
 :lang: en
 :slug: diecutter-0-5-released
 
-We have just released `diecutter <https://diecutter.readthedocs.org/>`_ 0.5,
+We have just released `diecutter <https://diecutter.readthedocs.io/>`_ 0.5,
 which introduces support of remote templates. Let's explain why it does
 matter...
 

--- a/content/django-configuration-files-rebased.rst
+++ b/content/django-configuration-files-rebased.rst
@@ -384,5 +384,5 @@ Django.
 .. _`mr.developer`: https://pypi.python.org/pypi/mr.developer
 .. _`extra-paths option of z3c.recipe.scripts`:
    https://pypi.python.org/pypi/zc.recipe.egg/2.0.0#specifying-extra-script-paths
-.. _`diecutter`: https://diecutter.readthedocs.org
+.. _`diecutter`: https://diecutter.readthedocs.io
 .. _`merge-based rebasing`: http://tech.novapost.fr/psycho-rebasing-en.html

--- a/content/django-downloadview-intro.rst
+++ b/content/django-downloadview-intro.rst
@@ -99,13 +99,13 @@ You have the download view, let's optimize the streaming. Depending on your
 use case, you can enable global optimization with a middleware, or setup
 per-view optimizations via decorators.
 `Read the documentation about optimizations
-<http://django-downloadview.readthedocs.org/en/latest/optimizations/index.html>`_
+<https://django-downloadview.readthedocs.io/en/latest/optimizations/index.html>`_
 for details.
 
 As of version 1.0, django-downloadview has built-in support of `Nginx's
 X-Accel <http://wiki.nginx.org/X-accel>`_ only.
 But `contributions are welcome
-<http://django-downloadview.readthedocs.org/en/latest/dev.html>`_ ;)
+<https://django-downloadview.readthedocs.io/en/latest/dev.html>`_ ;)
 
 
 ******************
@@ -157,7 +157,7 @@ Nevertheless, there are features we like in django-sendfile:
 
    `Learn more about similarities and differences between django-sendfile and
    django-downloadview
-   <http://django-downloadview.readthedocs.org/en/latest/about/alternatives.html#django-sendfile>`_
+   <https://django-downloadview.readthedocs.io/en/latest/about/alternatives.html#django-sendfile>`_
    in the latter's documentation.
 
 `Follow "unique backend" story on the bugtracker
@@ -196,9 +196,9 @@ wrappers can be used out of the box!
 References
 **********
 
-* `Online documentation <http://django-downloadview.readthedocs.org>`_
+* `Online documentation <https://django-downloadview.readthedocs.io>`_
 * Have a look at `alternatives and related projects
-  <http://django-downloadview.readthedocs.org/en/latest/about/alternatives.html>`_.
+  <https://django-downloadview.readthedocs.io/en/latest/about/alternatives.html>`_.
 * `django-downloadview on PyPI
   <http://pypi.python.org/pypi/django-downloadview>`_
 * `Issues and feature requests

--- a/content/django-queryset-only.rst
+++ b/content/django-queryset-only.rst
@@ -55,7 +55,7 @@ méthode **action()** du modèle.
 
 
 Si on analyse cette requête avec la commande debugsqlshell de la
-`debugtoolbar <http://django-debug-toolbar.readthedocs.org/>`_ de
+`debugtoolbar <https://django-debug-toolbar.readthedocs.io/>`_ de
 Django on obtient :
 
 

--- a/content/django-xworkflows.rst
+++ b/content/django-xworkflows.rst
@@ -17,7 +17,7 @@ C'est donc l'occasion pour moi de faire un petit bilan de ce que j'ai
 appris durant ce mois.
 
 J'aimerais pour commencer vous parler de `django-xworkflows
-<http://django-xworkflows.readthedocs.org/en/latest/>`_.
+<https://django-xworkflows.readthedocs.io/en/latest/>`_.
 
 ***************************************************
 Gestion des états d'un objet avec django-xworkflows
@@ -241,4 +241,4 @@ stable et correct.
 
 Si vous souhaitez en savoir plus sur notre service de génération des
 miniatures, allez voir `la documentation de Thumbnailer
-<http://thumbnailer.rtfd.org/>`_.
+<https://thumbnailer.readthedocs.io/>`_.

--- a/content/images/slides/circus.html
+++ b/content/images/slides/circus.html
@@ -1826,7 +1826,7 @@ dur à étendre, UI web pas terrible, pas de stdout temps reel.</li>
 <li>Socket réinstanciée avec <em>socket.fromfd()</em></li>
 <li>plusieurs backends: gevent, meinheld, waitress, wsgiref, eventlet</li>
 </ul>
-<p><a class="reference external" href="http://chaussette.readthedocs.org">http://chaussette.readthedocs.org</a></p></section>
+<p><a class="reference external" href="https://chaussette.readthedocs.io">https://chaussette.readthedocs.io</a></p></section>
             
           </div>
           <div class="presenter_notes">

--- a/content/images/slides/djangocon-toulouse-2012-documentation.html
+++ b/content/images/slides/djangocon-toulouse-2012-documentation.html
@@ -1479,7 +1479,7 @@ Guide du contributeur, conventions
 <li>Feedback-driven</li>
 <li>Support-driven</li>
 </ul>
-<p>=&gt; D'autres astuces sur <a class="reference external" href="http://docness.readthedocs.org">http://docness.readthedocs.org</a></p></section>
+<p>=&gt; D'autres astuces sur <a class="reference external" href="https://docness.readthedocs.io">https://docness.readthedocs.io</a></p></section>
             
           </div>
           <div class="presenter_notes">

--- a/content/images/slides/djangocon-toulouse-2012-documentation.txt
+++ b/content/images/slides/djangocon-toulouse-2012-documentation.txt
@@ -76,7 +76,7 @@ Une doc efficace
 * Feedback-driven
 * Support-driven
 
-=> D'autres astuces sur `<http://docness.readthedocs.org>`_
+=> D'autres astuces sur `<https://docness.readthedocs.io>`_
 
 ****
 

--- a/content/images/slides/ionyweb-tolosa.html
+++ b/content/images/slides/ionyweb-tolosa.html
@@ -1566,7 +1566,7 @@ fonctionnel puis ensuite c'est du Django normal.</li>
             
             <section><ul class="simple">
 <li><a class="reference external" href="http://github.com/ionyse/ionyweb">http://github.com/ionyse/ionyweb</a></li>
-<li><a class="reference external" href="http://ionyweb.rtfd.org/">http://ionyweb.rtfd.org/</a></li>
+<li><a class="reference external" href="https://ionyweb.readthedocs.io/">https://ionyweb.readthedocs.io/</a></li>
 <li>Posez vos questions &#64;Natim</li>
 <li>Il faut que vous le testiez : <a class="reference external" href="http://www.ionyweb-studio.com/">http://www.ionyweb-studio.com/</a></li>
 <li>Il y a un atelier demain.</li>

--- a/content/images/slides/ionyweb.html
+++ b/content/images/slides/ionyweb.html
@@ -1566,7 +1566,7 @@ fonctionnel puis c'est du Django</li>
             
             <section><ul class="simple">
 <li><a class="reference external" href="http://github.com/ionyse/ionyweb">http://github.com/ionyse/ionyweb</a></li>
-<li><a class="reference external" href="http://ionyweb.rtfd.org/">http://ionyweb.rtfd.org/</a></li>
+<li><a class="reference external" href="https://ionyweb.readthedocs.io/">https://ionyweb.readthedocs.io/</a></li>
 <li>Posez vos questions &#64;Natim</li>
 <li>Il faut que vous le testiez.</li>
 <li>Il faut que vous rajoutiez ce qu'il manque dans la doc.</li>

--- a/content/pyconfr-2012-review.rst
+++ b/content/pyconfr-2012-review.rst
@@ -26,7 +26,7 @@ pendant les deux premiers jours.
 Circus_ est un gestionnaire de processus et de sockets écrit en python par
 `Mozilla Services`_.
 
-.. _Circus: http://circus.readthedocs.org/en/latest/
+.. _Circus: https://circus.readthedocs.io/en/latest/
 .. _`Mozilla Services`: https://github.com/mozilla-services
 
 
@@ -417,13 +417,13 @@ Plus d'infos et des screeshots ici :
 http://ziade.org/2012/08/22/marteau-distributed-load-tests/
 
 .. _`Django Debug Toolbar`: https://github.com/django-debug-toolbar/django-debug-toolbar
-.. _South: http://south.readthedocs.org/en/latest/about.html
-.. _Sentry: http://sentry.readthedocs.org/en/latest/index.html
+.. _South: https://south.readthedocs.io/en/latest/about.html
+.. _Sentry: https://sentry.readthedocs.io/en/latest/index.html
 .. _SPORE: https://github.com/SPORE/specifications
-.. _Spyre: http://spyre.readthedocs.org/en/latest/index.html
+.. _Spyre: https://spyre.readthedocs.io/en/latest/index.html
 .. _PyBABE: https://github.com/fdouetteau/PyBabe
 .. _Tornado: http://www.tornadoweb.org/
-.. _Cornice: http://cornice.readthedocs.org/en/latest/index.html
+.. _Cornice: https://cornice.readthedocs.io/en/latest/index.html
 
 
 **********

--- a/content/pyconfr-2012.rst
+++ b/content/pyconfr-2012.rst
@@ -26,7 +26,7 @@ Voici les sprints auxquels nous comptons participer :
 Circus : A Process & Socket Manager
 ===================================
 
- * Site internet : http://circus.readthedocs.org/en/latest/
+ * Site internet : https://circus.readthedocs.io/en/latest/
 
 Description
 -----------

--- a/content/pytong-2013-review.rst
+++ b/content/pytong-2013-review.rst
@@ -163,21 +163,21 @@ D'autres informations en vrac
   avec pip c'est pas si compliqué.
 
 
-.. _`Salt`: https://salt.readthedocs.org/en/latest/
+.. _`Salt`: https://salt.readthedocs.io/en/latest/
 .. _WebTest: http://webtest.pythonpaste.org/en/latest/
-.. _South: http://south.readthedocs.org/en/latest/
+.. _South: https://south.readthedocs.io/en/latest/
 .. _Pygal: http://pygal.org/
 .. _Weasyprint: http://weasyprint.org/
 .. _Mezzanine: http://mezzanine.jupo.org/
 .. _`Django Avancé`: http://www.eyrolles.com/Informatique/Livre/django-avance-9782212134155
 .. _Brython: http://www.brython.info/
 .. _Buildout: http://www.buildout.org/en/latest/
-.. _Daybed: http://daybed.readthedocs.org/en/latest/
+.. _Daybed: https://daybed.readthedocs.io/en/latest/
 .. _Polymer: http://www.polymer-project.org/
 .. _`ØMQ`: http://www.zeromq.org/
 .. _Tornado: http://www.tornadoweb.org/
 .. _`les trucs et astuces`: https://speakerdeck.com/lothiraldan/use-omq-and-tornado-for-fun-and-profits
-.. _Cornice: http://cornice.readthedocs.org/en/latest/
+.. _Cornice: https://cornice.readthedocs.io/en/latest/
 .. _Collander: http://docs.pylonsproject.org/projects/colander/en/latest/
 .. _CouchDB: http://couchdb.apache.org/
 .. _`sprint Daybed`: http://wiki.python.org/moin/AfpyCamp2013

--- a/content/second-circus-sprint.rst
+++ b/content/second-circus-sprint.rst
@@ -54,7 +54,7 @@ Tarek did a nice work on adding hooks_ to watchers, which are now available!
 Check the docs_ for more information.
 
 .. _hooks: https://github.com/mozilla-services/circus/pull/299
-.. _docs: http://circus.readthedocs.org/en/latest/hooks/#hooks
+.. _docs: https://circus.readthedocs.io/en/latest/hooks/#hooks
 
 What this allows is to plug callback functions at various places during the
 watcher startup and shutdown process:

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -14,7 +14,7 @@ DEFAULT_LANG = 'fr'
 LINKS =  (('Novapost', 'http://www.novapost.fr/'),
           ('Django-fr', 'http://www.django-fr.org/'),
           ('Rencontres Django', 'http://rencontres.django-fr.org/'),
-          ('Django Story', 'http://django-story.rtfd.org/'),)
+          ('Django Story', 'https://django-story.readthedocs.io/'),)
 
 # Social widget
 SOCIAL = (('Benoit Bryon', 'https://github.com/benoitbryon'),


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.